### PR TITLE
Provide Argon2id overloads to pass password hashes as strings

### DIFF
--- a/src/Geralt.Tests/Argon2idTests.cs
+++ b/src/Geralt.Tests/Argon2idTests.cs
@@ -189,7 +189,7 @@ public class Argon2idTests
 
     [TestMethod]
     [DataRow("correct horse battery staple", Argon2id.MinIterations, Argon2id.MinMemorySize)]
-    public void ComputeHash_Valid_String(string password, int iterations, int memorySize)
+    public void ComputeHash_String_Valid(string password, int iterations, int memorySize)
     {
         Span<byte> p = Encoding.UTF8.GetBytes(password);
 
@@ -206,7 +206,7 @@ public class Argon2idTests
 
     [TestMethod]
     [DynamicData(nameof(StringTestVectors), DynamicDataSourceType.Method)]
-    public void VerifyHash_Valid_String(bool expected, string hash, string password)
+    public void VerifyHash_String_Valid(bool expected, string hash, string password)
     {
         Span<byte> p = Encoding.UTF8.GetBytes(password);
 
@@ -218,7 +218,7 @@ public class Argon2idTests
     [TestMethod]
     [DataRow("$argon2i$v=19$m=4096,t=3,p=1$eXNtbzQwOTFzajAwMDAwMA$Bb7qAql9aguCTBpLP4PVnlBd+ehJ5rX0R7smB/FggOM", "password")]
     [DataRow("$argon2d$v=19$m=4096,t=3,p=1$YTBxd2k1bXBhZHIwMDAwMA$3MM5BChSl8q+MQED0fql0nwP5ykjHdBrGE0mVJHFEUE", "password")]
-    public void VerifyHash_Tampered_String(string hash, string password)
+    public void VerifyHash_String_Tampered(string hash, string password)
     {
         var p = Encoding.UTF8.GetBytes(password);
 
@@ -235,10 +235,28 @@ public class Argon2idTests
     [DataRow("$argon2id$v=19$m=4882,t=2,p=1$bA81arsiX", "")]
     [DataRow("$argon2id$v=19$m=4882,t=2,p=1$bA81arsiXysd3WbTRzmEOw$Nm8QBM+7", "")]
     [DataRow("$argon2id$v=19$m=4882,t=2,p=1$bA81arsiXysd3WbTRzmEOw$Nm8QBM+7RH1DXo9rvp5cwKEOOOfD2g6JuxlXihoNcp", "")]
-    public void VerifyHash_Invalid_String(string hash, string password)
+    public void VerifyHash_String_Invalid(string hash, string password)
     {
         var p = Encoding.UTF8.GetBytes(password);
 
-        Assert.IsFalse(Argon2id.VerifyHash(hash, p));
+        bool valid = Argon2id.VerifyHash(hash, p);
+        Assert.IsFalse(valid);
+    }
+
+    [TestMethod]
+    [DataRow("$argon2id$", "")]
+    [DataRow("$argon2id$v=1", "")]
+    [DataRow("$argon2id$v=19", "")]
+    [DataRow("$argon2id$v=19$", "")]
+    [DataRow("$argon2id$v=19$m=4882,t=", "")]
+    [DataRow("$argon2id$v=19$m=4882,t=2,p=1$", "")]
+    [DataRow("$argon2id$v=19$m=4882,t=2,p=1$bA81arsiX", "")]
+    [DataRow("$argon2id$v=19$m=4882,t=2,p=1$bA81arsiXysd3WbTRzmEOw$Nm8QBM+7", "")]
+    [DataRow("$argon2id$v=19$m=4882,t=2,p=1$bA81arsiXysd3WbTRzmEOw$Nm8QBM+7RH1DXo9rvp5cwKEOOOfD2g6JuxlXihoNcp", "")]
+    public void NeedsRehash_String_Invalid(string hash, string password)
+    {
+        var p = Encoding.UTF8.GetBytes(password);
+
+        Assert.ThrowsException<FormatException>(() => Argon2id.NeedsRehash(hash, Argon2id.MinIterations, Argon2id.MinMemorySize));
     }
 }

--- a/src/Geralt/Interop/Interop.Argon2id.cs
+++ b/src/Geralt/Interop/Interop.Argon2id.cs
@@ -23,7 +23,7 @@ internal static partial class Interop
 
         [LibraryImport(DllName)]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        internal static unsafe partial int crypto_pwhash_str_alg(sbyte* hash, ReadOnlySpan<byte> password, ulong passwordLength, ulong iterations, nuint memorySize, int algorithm);
+        internal static partial int crypto_pwhash_str_alg(nint hash, ReadOnlySpan<byte> password, ulong passwordLength, ulong iterations, nuint memorySize, int algorithm);
 
         [LibraryImport(DllName)]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/Geralt/Interop/Interop.Argon2id.cs
+++ b/src/Geralt/Interop/Interop.Argon2id.cs
@@ -23,10 +23,22 @@ internal static partial class Interop
 
         [LibraryImport(DllName)]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        internal static unsafe partial int crypto_pwhash_str_alg(sbyte* hash, ReadOnlySpan<byte> password, ulong passwordLength, ulong iterations, nuint memorySize, int algorithm);
+
+        [LibraryImport(DllName)]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
         internal static partial int crypto_pwhash_str_verify(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> password, ulong passwordLength);
 
         [LibraryImport(DllName)]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        internal static partial int crypto_pwhash_str_verify([MarshalAs(UnmanagedType.LPStr)] string hash, ReadOnlySpan<byte> password, ulong passwordLength);
+
+        [LibraryImport(DllName)]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
         internal static partial int crypto_pwhash_str_needs_rehash(ReadOnlySpan<byte> hash, ulong iterations, nuint memorySize);
+
+        [LibraryImport(DllName)]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        internal static partial int crypto_pwhash_str_needs_rehash([MarshalAs(UnmanagedType.LPStr)] string hash, ulong iterations, nuint memorySize);
     }
 }


### PR DESCRIPTION
It can be a bit tricky to convert the password hash correctly between `Span<byte>` and `string`, so it might be helpful to provide overloads in the `Argon2id` class that do the conversion for the user.

The unsafe code can be replaced with `Marshal.AllocHGlobal`, `Marshal.PtrToStringAnsi`, and `Marshal.FreeHGlobal` in a `try ... finally ...` if preferred.